### PR TITLE
Removed hostname step to fix the bug

### DIFF
--- a/doc/CORTX_on_Open_Virtual_Appliance.rst
+++ b/doc/CORTX_on_Open_Virtual_Appliance.rst
@@ -35,20 +35,6 @@ The procedure to install CORTX on OVA is mentioned below.
    ::
      sudo su -
    
-#. Change the hostname by running the following command:
-
-   * **hostnamectl set-hostname --static --transient --pretty <new-name>**
-  
-     If you receive **Access denied** message, remove immutable settings on the **/etc/hostname** file and run the command again. To remove immutable setting from **/etc/hostname**, run the following command.
-     
-     * **chattr -i /etc/hostname**
-  
-     To verify the change in hostname, run the following command:
- 
-     * **hostnamectl status**
-   
-   **Note**: Both short hostnames and FQDNs are accepted. If you do not have a DNS server with which to register the VM, you can access it directly using its IP addresses. However, the hostname is mandatory and should be configured.
-
 #. **For Oracle VM VirtualBox Users ONLY**:
    
    


### PR DESCRIPTION
Removed hostname step to fix the bug as reported in EOS-20584

OVA is a single node deployment and Ideally there should not be a need to change the hostname on an OVA once imported, unless there are multiple devices being deployed. It should be frozen with the OVA and since OVA is imported on hypervisor, this would mostly be a sandboxed environment.